### PR TITLE
docs: add initial docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+## Style
+
+This project uses `google-java-format` for code formatting. Please see that project's [README](https://github.com/google/google-java-format#using-the-formatter) for usage instructions.
+
+## Commit Messages
+
+This project uses the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#summary) standard, please follow this standard with your commit messages.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# frontend
+
+## Usage
+
+```sh
+gradle build
+gradle run
+```
+
+See [tli-group-4-grimm/hosting](https://github.com/tli-group-4-grimm/hosting) for more details on usage in tandem with the frontend via Docker or other means.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
This PR adds basic standalone usage instructions to the README as well as contributing instructions.