### PR TITLE
ci: rename actions and fetch latest version of google-java-format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,17 +1,10 @@
-# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
-
-name: Java CI with Gradle
-
+name: Build with Gradle
 on:
   push:
     branches: [ '**' ]
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,8 @@ jobs:
           distribution: adopt
         uses: actions/setup-java@v2.3.1
       - name: Set up Google Java Format
-        # TOOD: Fetch latest version
-        run: curl -L https://github.com/google/google-java-format/releases/download/v1.12.0/google-java-format-1.12.0-all-deps.jar -o google-java-format.jar
-      - name: Lint files
+        run: curl -L "$(curl --silent -X 'GET' https://api.github.com/repos/google/google-java-format/releases/latest | jq -r '.assets[]|select(.name|endswith("-all-deps.jar")).browser_download_url')" -o google-java-format.jar
+      - name: Lint with Google Java Format
         run: >
           exec java \
             --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: CI with Google Java Format
+name: Lint with Google Java Format
 on:
   push:
     branches: [ "**" ]


### PR DESCRIPTION
This PR makes the action naming more consistent and ensures that the lates version of `google-java-format` is used.