### PR TITLE
refactor!: consume text/plain in `/vehicle` route

### DIFF
--- a/api-v1.yaml
+++ b/api-v1.yaml
@@ -24,7 +24,7 @@ paths:
       - "vehicles"
       summary: "Get vehicles matching data"
       consumes:
-      - "application/json"
+      - "text/plain"
       produces:
       - "application/json"
       parameters:
@@ -33,10 +33,7 @@ paths:
         description: "Vehicle string to search for"
         required: true
         schema:
-          type: "object"
-          properties:
-            searchString:
-              type: "string"
+          type: "string"
       responses:
         '200':
           description: "All matching cars"


### PR DESCRIPTION
This PR switches the API spec to consume `text/plain` on the search route because using JSON is unecessary since the only value that we need to submit is the search string. This PR doesn't require testing as it is only a change to the specification.