### PR TITLE
feat: retry database connection a few times before failing

### DIFF
--- a/src/main/java/server/main.java
+++ b/src/main/java/server/main.java
@@ -18,6 +18,18 @@ import java.sql.SQLException;
 class Server {
     public static void main(String[] args) {
         Logger l = LoggerFactory.getLogger();
+        for (int retries = 0; retries < 5; retries++) {
+            try {
+                DataBaseFetcher.connectAndMigrate();
+                break;
+            } catch (SQLException e) {
+                l.warn("could not connect to database, retrying");
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException te) {
+                }
+            }
+        }
         try {
             DataBaseFetcher.connectAndMigrate();
         } catch (SQLException e) {


### PR DESCRIPTION
This PR adds some code to the main class to retry the database connection a few times before failing, with a 1 second delay in between. This should help avoid race conditions, such as the database not being ready when the backend tries to connect, which is somewhat common right now particularly on the production docker-compose stack.