### PR TITLE
ci: fix credentials not being substituted in deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,22 +6,14 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    env:
-      REPO_ACCESS_TOKEN: "{{ secrets.REPO_ACCESS_TOKEN }}"
     steps:
       - name: Make repository dispatch request
-        run: >
-          curl -v -X "POST" -H "Authorization: token $REPO_ACCESS_TOKEN" https://api.github.com/repos/tli-group-4-grimm/hosting/dispatches -d '{"event_type": "deploy"}'
+        run: 'curl -v -X "POST" -H "Authorization: token $REPO_ACCESS_TOKEN" https://api.github.com/repos/tli-group-4-grimm/hosting/dispatches -d "{\"event_type\": \"deploy\"}"'
+        env:
+          REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
       - name: Wait for action to start
-        run: >
-          while curl --silent -X "GET" -H "Authorization: token $REPO_ACCESS_TOKEN" https://api.github.com/repos/tli-group-4-grimm/hosting/actions/runs | jq -e '.workflow_runs[0].conclusion != null' > /dev/null; do
-              sleep 1
-          done
+        run: 'while curl --silent -X "GET" https://api.github.com/repos/tli-group-4-grimm/hosting/actions/runs | jq -e ".workflow_runs[0].conclusion != null" > /dev/null; do sleep 1; done'
       - name: Wait for action to finish
-        run: >
-          while curl --silent -X "GET" -H "Authorization: token $REPO_ACCESS_TOKEN" https://api.github.com/repos/tli-group-4-grimm/hosting/actions/runs | jq -e '.workflow_runs[0].conclusion == null' > /dev/null; do
-              sleep 1
-          done
+        run: 'while curl --silent -X "GET" https://api.github.com/repos/tli-group-4-grimm/hosting/actions/runs | jq -e ".workflow_runs[0].conclusion == null" > /dev/null; do sleep 1; done'
       - name: Register result
-        run: >
-          curl -v -X "GET" -H "Authorization: token $REPO_ACCESS_TOKEN" https://api.github.com/repos/tli-group-4-grimm/hosting/actions/runs | jq -e '.workflow_runs[0].conclusion == "success"'
+        run: 'curl -v -X "GET" https://api.github.com/repos/tli-group-4-grimm/hosting/actions/runs | jq -e ".workflow_runs[0].conclusion == \"success\""'


### PR DESCRIPTION
Sorry, this should hopefully be the last of it but there's a chance I messed up the string escaping. This is another thing that I can't test unless it's on the main branch... so we'll see what happens.