### PR TITLE
fix: update placholder inserter to match new csv fields

### DIFF
--- a/src/main/java/fetchers/DataBaseFetcher.java
+++ b/src/main/java/fetchers/DataBaseFetcher.java
@@ -67,11 +67,11 @@ public class DataBaseFetcher {
                 String statement = "INSERT INTO cars VALUES (?, ?, ?, ?, ?, ?)";
                 PreparedStatement pst = connection.prepareStatement(statement);
                 pst.setInt(1, Integer.parseInt(fields[0]));
-                pst.setDouble(2, Double.parseDouble(fields[4]));
-                pst.setString(3, fields[1]);
-                pst.setString(4, fields[2]);
-                pst.setInt(5, Integer.parseInt(fields[3]));
-                pst.setInt(6, 0);
+                pst.setDouble(2, Double.parseDouble(fields[5]));
+                pst.setString(3, fields[2]);
+                pst.setString(4, fields[3]);
+                pst.setInt(5, Integer.parseInt(fields[4]));
+                pst.setInt(6, Integer.parseInt(fields[1]));
                 pst.execute();
             }
         } catch (SQLException e) {


### PR DESCRIPTION
This pull request updates the method that inserts placholder data so that it uses the new fields in the CSV. This pull request can be tested by removing the previous database container (you can do this with `docker ps -aq | xargs docker rm` as long as you don't care about any of your other containers), then ensuring that the placeholder data is properly inserted.

Closes #49.